### PR TITLE
fix: Upgrade to AWS Provider v5 and add variable ip rate limit endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ User Pool.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Friendly name of the rule. | `string` | n/a | yes |
+| <a name="input_rate_limit_positional_constraint"></a> [rate\_limit\_positional\_constraint](#input\_rate\_limit\_positional\_constraint) | The area within the portion of a web request that you want AWS WAF to search for rate limiting headers. Valid values: EXACTLY, STARTS\_WITH, ENDS\_WITH, CONTAINS, and CONTAINS\_WORD. The default value is EXACTLY. | `string` | `"STARTS_WITH"` | no |
+| <a name="input_rate_limit_search_string"></a> [rate\_limit\_search\_string](#input\_rate\_limit\_search\_string) | String value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in field\_to\_match. The maximum length of the value is 50 bytes. | `string` | `"/api"` | no |
 | <a name="input_resource_arn"></a> [resource\_arn](#input\_resource\_arn) | The Amazon Resource Name (ARN) of the resource to associate with the web ACL. This must be an ARN of an Application Load Balancer, an Amazon API Gateway stage, or an Amazon Cognito User Pool. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to the Resources. | `map(any)` | `{}` | no |
 
@@ -68,9 +70,9 @@ No outputs.
 
 ## Resources
 
-- resource.aws_wafv2_ip_set.ip_blocking (main.tf#399)
+- resource.aws_wafv2_ip_set.ip_blocking (main.tf#291)
 - resource.aws_wafv2_web_acl.main (main.tf#12)
-- resource.aws_wafv2_web_acl_association.main (main.tf#417)
+- resource.aws_wafv2_web_acl_association.main (main.tf#309)
 
 # Examples
 ### Basic Example

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -137,28 +137,6 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesBotControlRuleSet"
         vendor_name = "AWS"
-
-        dynamic "excluded_rule" {
-          for_each = [
-            "CategoryAdvertising",
-            "CategoryArchiver",
-            "CategoryContentFetcher",
-            "CategoryHttpLibrary",
-            "CategoryMiscellaneous",
-            "CategoryMonitoring",
-            "CategoryScrapingFramework",
-            "CategorySearchEngine",
-            "CategorySecurity",
-            "CategorySeo",
-            "CategorySocialMedia",
-            "SignalNonBrowserUserAgent",
-            "SignalAutomatedBrowser",
-            "SignalKnownBotDataCenter",
-          ]
-          content {
-            name = excluded_rule.value
-          }
-        }
       }
     }
 
@@ -181,15 +159,6 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesAmazonIpReputationList"
         vendor_name = "AWS"
-
-        dynamic "excluded_rule" {
-          for_each = [
-            "AWSManagedIPReputationList",
-          ]
-          content {
-            name = excluded_rule.value
-          }
-        }
       }
     }
 
@@ -212,36 +181,6 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-
-        dynamic "excluded_rule" {
-          for_each = [
-            "CrossSiteScripting_BODY",
-            "CrossSiteScripting_COOKIE",
-            "CrossSiteScripting_QUERYARGUMENTS",
-            "CrossSiteScripting_URIPATH",
-            "EC2MetaDataSSRF_BODY",
-            "EC2MetaDataSSRF_COOKIE",
-            "EC2MetaDataSSRF_QUERYARGUMENTS",
-            "EC2MetaDataSSRF_URIPATH",
-            "GenericLFI_BODY",
-            "GenericLFI_QUERYARGUMENTS",
-            "GenericLFI_URIPATH",
-            "GenericRFI_BODY",
-            "GenericRFI_QUERYARGUMENTS",
-            "GenericRFI_URIPATH",
-            "NoUserAgent_HEADER",
-            "RestrictedExtensions_QUERYARGUMENTS",
-            "RestrictedExtensions_URIPATH",
-            "SizeRestrictions_BODY",
-            "SizeRestrictions_Cookie_HEADER",
-            "SizeRestrictions_QUERYSTRING",
-            "SizeRestrictions_URIPATH",
-            "UserAgent_BadBots_HEADER",
-          ]
-          content {
-            name = excluded_rule.value
-          }
-        }
       }
     }
 
@@ -264,18 +203,6 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesKnownBadInputsRuleSet"
         vendor_name = "AWS"
-
-        dynamic "excluded_rule" {
-          for_each = [
-            "BadAuthToken_COOKIE_AUTHORIZATION",
-            "ExploitablePaths_URIPATH",
-            "Host_localhost_HEADER",
-            "PROPFIND_METHOD",
-          ]
-          content {
-            name = excluded_rule.value
-          }
-        }
       }
     }
 
@@ -298,17 +225,6 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesLinuxRuleSet"
         vendor_name = "AWS"
-
-        dynamic "excluded_rule" {
-          for_each = [
-            "LFI_BODY",
-            "LFI_QUERYARGUMENTS",
-            "LFI_URIPATH",
-          ]
-          content {
-            name = excluded_rule.value
-          }
-        }
       }
     }
 
@@ -331,16 +247,6 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesPHPRuleSet"
         vendor_name = "AWS"
-
-        dynamic "excluded_rule" {
-          for_each = [
-            "PHPHighRiskMethodsVariables_BODY",
-            "PHPHighRiskMethodsVariables_QUERYARGUMENTS",
-          ]
-          content {
-            name = excluded_rule.value
-          }
-        }
       }
     }
 
@@ -363,20 +269,6 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesSQLiRuleSet"
         vendor_name = "AWS"
-
-        dynamic "excluded_rule" {
-          for_each = [
-            "SQLiExtendedPatterns_QUERYARGUMENTS",
-            "SQLi_BODY",
-            "SQLi_COOKIE",
-            "SQLi_QUERYARGUMENTS",
-            "SQLi_QUERYSTRING_COUNT",
-            "SQLi_URIPATH",
-          ]
-          content {
-            name = excluded_rule.value
-          }
-        }
       }
     }
 

--- a/main.tf
+++ b/main.tf
@@ -59,8 +59,8 @@ resource "aws_wafv2_web_acl" "main" {
 
         scope_down_statement {
           byte_match_statement {
-            positional_constraint = "STARTS_WITH"
-            search_string         = "/api/"
+            positional_constraint = var.rate_limit_positional_constraint
+            search_string         = var.rate_limit_search_string
 
             field_to_match {
               uri_path {}

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,18 @@ variable "name" {
   type        = string
 }
 
+variable "rate_limit_positional_constraint" {
+  description = "The area within the portion of a web request that you want AWS WAF to search for rate limiting headers. Valid values: EXACTLY, STARTS_WITH, ENDS_WITH, CONTAINS, and CONTAINS_WORD. The default value is EXACTLY."
+  default     = "STARTS_WITH"
+  type        = string
+}
+
+variable "rate_limit_search_string" {
+  description = "String value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in field_to_match. The maximum length of the value is 50 bytes."
+  default     = "/api"
+  type        = string
+}
+
 variable "resource_arn" {
   description = "The Amazon Resource Name (ARN) of the resource to associate with the web ACL. This must be an ARN of an Application Load Balancer, an Amazon API Gateway stage, or an Amazon Cognito User Pool."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.4"
+      version = ">= 5.0, < 6.0"
     }
   }
 }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

Issues with the "new" AWS Provider >= 5
Add functionality to set the ip rate limit specific endpoint

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [x] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
